### PR TITLE
[fix] postCardTryCount api response.json() 에러 해결

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -184,7 +184,7 @@ export async function postCardTryCount({
 }) {
   const accessToken = loadItem('accessToken');
   const url = `https://www.quizmap.co.kr/api/cards/${id}/learning-log`;
-  const response = await fetch(url, {
+  await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -194,8 +194,6 @@ export async function postCardTryCount({
       tryCount, learningDateTime, learningSeconds,
     }), // TODO: learningSecond's'
   });
-  const data = await response.json();
-  return data;
 }
 
 export async function patchStarCount({ id, starCount }) {


### PR DESCRIPTION
"Uncaught (in promise) SyntaxError: Unexpected token H in JSON at position 0" → error fixed
- response.json()에서 에러 발생. response가 json 형태가 아닌데 JSON으로 파싱하려고 함