### PR TITLE
[feat] 스페이스바로 flip & ←/→로 X/O 클릭하도록 구현 

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -57,18 +57,6 @@ export function setIsLastPage(isLastPage) {
   };
 }
 
-export function nextCard() {
-  return (dispatch, getState) => {
-    const { cards } = getState();
-
-    if (cards.length > 0) {
-      dispatch(setFlipped(false));
-    } else {
-      dispatch(setIsLastPage(true));
-    }
-  };
-}
-
 export function setTitleChanged(isTitleChanged) {
   return {
     type: 'setTitleChanged',
@@ -333,8 +321,14 @@ export function clickWrongCard(id) {
 
     const filteredCards = cards.filter((card) => card.id !== id);
     const newCards = filteredCards.concat([cards[index]]);
+
+    if (newCards.length > 0) {
+      dispatch(setFlipped(false));
+    } else {
+      dispatch(setIsLastPage(true));
+    }
+
     dispatch(setCards(newCards));
-    dispatch(nextCard(id));
   };
 }
 
@@ -364,8 +358,14 @@ export function clickCorrectCard(id) {
     await postCardTryCount({
       id, tryCount, learningDateTime, learningSeconds,
     });
+
+    if (filteredCards.length > 0) {
+      dispatch(setFlipped(false));
+    } else {
+      dispatch(setIsLastPage(true));
+    }
+
     dispatch(setCards(filteredCards));
-    dispatch(nextCard(id));
   };
 }
 

--- a/src/containers/LearnCardsContainer.jsx
+++ b/src/containers/LearnCardsContainer.jsx
@@ -4,13 +4,12 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import styled from '@emotion/styled';
 
+import { useEffect } from 'react';
 import Card from '../components/learn/Card';
 import CardButtons from '../components/learn/CardButtons';
-import NoMoreCards from '../components/learn/NoMoreCards';
 import CardsetPath from '../components/learn/CardsetPath';
 import Notes from '../components/learn/Notes';
 import LearningSidebar from '../components/learn/LearningSidebar';
-import Loading from '../components/common/Loading';
 
 import { get } from '../utils';
 
@@ -70,47 +69,34 @@ export default function LearnCardsContainer({ id }) {
 
   const cards = useSelector(get('cards'));
   const flipped = useSelector(get('flipped'));
-  const isLastPage = useSelector(get('isLastPage'));
   const isNotesHidden = useSelector(get('isNotesHidden'));
   const notes = useSelector(get('notes'));
-
-  if (isLastPage) {
-    return (
-      <NoMoreCards id={id} />
-    );
-  }
-
-  if (cards.length === 0) {
-    return (
-      <div style={{
-        position: 'absolute',
-        top: '50%',
-        left: '50%',
-        transform: 'translate(-50%, -50%)',
-      }}
-      >
-        <Loading
-          size={80}
-        />
-      </div>
-    );
-  }
 
   const {
     id: cardId, topic, answer, pathDtos, starCount,
   } = cards[0];
+
+  const KEY_CODE = {
+    32: 'SPACE',
+    37: 'LEFT',
+    39: 'RIGHT',
+  };
+
+  const clearNote = () => {
+    dispatch(setNotes(''));
+  };
 
   const handleFlip = () => {
     dispatch(flipCard());
   };
 
   const handleClickWrong = () => {
-    dispatch(setNotes(''));
+    clearNote();
     dispatch(clickWrongCard(cardId));
   };
 
   const handleClickCorrect = () => {
-    dispatch(setNotes(''));
+    clearNote();
     dispatch(clickCorrectCard(cardId));
   };
 
@@ -126,6 +112,24 @@ export default function LearnCardsContainer({ id }) {
     const { value } = e.target;
     dispatch(setNotes(value));
   };
+
+  const handleKeyDown = (event) => {
+    event.preventDefault();
+
+    const { keyCode } = event;
+    if (KEY_CODE[keyCode] === 'SPACE') {
+      handleFlip();
+    } else if (KEY_CODE[keyCode] === 'LEFT') {
+      handleClickWrong();
+    } else if (KEY_CODE[keyCode] === 'RIGHT') {
+      handleClickCorrect();
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [cards]);
 
   return (
     <div style={{ height: '100vh' }}>

--- a/src/pages/LearnPage.jsx
+++ b/src/pages/LearnPage.jsx
@@ -1,14 +1,19 @@
 import { useEffect } from 'react';
 
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { useParams } from 'react-router-dom';
 
 import LearnCardsContainer from '../containers/LearnCardsContainer';
+import NoMoreCards from '../components/learn/NoMoreCards';
+
+import Loading from '../components/common/Loading';
 
 import {
   initializeLearnPage,
 } from '../actions';
+
+import { get } from '../utils';
 
 export default function LearnPage({ params }) {
   const { id } = params || useParams();
@@ -18,6 +23,31 @@ export default function LearnPage({ params }) {
   useEffect(() => {
     dispatch(initializeLearnPage(id));
   }, [id]);
+
+  const cards = useSelector(get('cards'));
+  const isLastPage = useSelector(get('isLastPage'));
+
+  if (isLastPage) {
+    return (
+      <NoMoreCards id={id} />
+    );
+  }
+
+  if (cards.length === 0) {
+    return (
+      <div style={{
+        position: 'absolute',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+      }}
+      >
+        <Loading
+          size={80}
+        />
+      </div>
+    );
+  }
 
   return (
     <LearnCardsContainer id={id} />


### PR DESCRIPTION
# 내용
- 스페이스바 : flip 클릭
- ← : X 클릭
- → : O 클릭

## Error 해결
1. useEffect가 새로 실행될 때마다 handleKeyDown 함수가 생성되어 2배씩 중첩되어 실행되는 문제😨
> React는 컴포넌트가 마운트 해제되는 때에 정리(clean-up)를 실행한다.
- 따라서 React useEffect의 clean-up으로 removeEventListener을 실행하여 문제를 해결했다.

> ![image](https://user-images.githubusercontent.com/67737432/172046853-7e0003d5-7b62-401c-a72a-c268ca6ff313.png)
> React의 useEffect clean-up 어떻게 하는지 면접에서 물어봤는데 그때는 대답을 못했다😥😭

2. answer이 보이는 상태(flipped된 상태)로 '→' 키 누르면 다음 카드의 answer이 0.5초정도 보이고 question이 보이는 에러 해결
- cards state를 먼저 바꾼 다음에 flipped state를 바꿔서 생기는 문제였다.
- 따라서 flipped state를 먼저 바꾸고 → cards의 state를 바꿨더니 예상한대로 잘 동작한다.