### PR TITLE
[fix] notes 작성할 때는 스페이스바/왼쪽/오른쪽 키 눌러도 카드 조작 안되도록 수정

### DIFF
--- a/src/components/learn/Notes.jsx
+++ b/src/components/learn/Notes.jsx
@@ -43,7 +43,7 @@ export default function Notes({ notes, isNotesHidden, onChange }) {
   return (
     <NotesContainer isNotesHidden={isNotesHidden}>
       <Title>Notes</Title>
-      <TextArea value={notes} onChange={onChange} placeholder="write the answer in your own words!" />
+      <TextArea className="notes" value={notes} onChange={onChange} placeholder="write the answer in your own words!" />
     </NotesContainer>
   );
 }

--- a/src/containers/LearnCardsContainer.jsx
+++ b/src/containers/LearnCardsContainer.jsx
@@ -115,15 +115,19 @@ export default function LearnCardsContainer({ id }) {
   };
 
   const handleKeyDown = (event) => {
-    event.preventDefault();
+    const { classList } = event.target;
+    if (!classList.contains('notes')) {
+      event.preventDefault();
 
-    const { keyCode } = event;
-    if (KEY_CODE[keyCode] === 'SPACE') {
-      handleFlip();
-    } else if (KEY_CODE[keyCode] === 'LEFT') {
-      handleClickWrong();
-    } else if (KEY_CODE[keyCode] === 'RIGHT') {
-      handleClickCorrect();
+      const { keyCode } = event;
+
+      if (KEY_CODE[keyCode] === 'SPACE') {
+        handleFlip();
+      } else if (KEY_CODE[keyCode] === 'LEFT') {
+        handleClickWrong();
+      } else if (KEY_CODE[keyCode] === 'RIGHT') {
+        handleClickCorrect();
+      }
     }
   };
 


### PR DESCRIPTION
# how
- `event.target`의 classList에 Notes의 클래스 이름인 "notes"가 포함되어 있을 경우에는 handleKeyDown 실행하지 않도록 수정